### PR TITLE
Fix simple typo

### DIFF
--- a/bin/phinder
+++ b/bin/phinder
@@ -20,7 +20,7 @@ $command = null;
 $test = false;
 
 function showHelpAndDie($msg=null) {
-    if ($mst !== null) fwrite(STDERR, $msg . "\n");
+    if ($msg !== null) fwrite(STDERR, $msg . "\n");
     fwrite(STDERR, <<<EOS
 Usage  : phinder [-j|--json] [-r|--rule <rule-path>]  [-p|--php <php-path>] [-q|--quicktest <pattern>]
 


### PR DESCRIPTION
## Before

```
% bin/phinder --help
PHP Notice:  Undefined variable: mst in /home/wata727/ghq/github.com/tomokinakamaru/phinder/bin/phinder on line 23
PHP Stack trace:
PHP   1. {main}() /home/wata727/ghq/github.com/tomokinakamaru/phinder/bin/phinder:0
PHP   2. showHelpAndDie() /home/wata727/ghq/github.com/tomokinakamaru/phinder/bin/phinder:66
Usage  : phinder [-j|--json] [-r|--rule <rule-path>]  [-p|--php <php-path>] [-q|--quicktest <pattern>]
```

## After

```
% bin/phinder --help

Usage  : phinder [-j|--json] [-r|--rule <rule-path>]  [-p|--php <php-path>] [-q|--quicktest <pattern>]
```