### PR TITLE
Suppress warnings for undefined index

### DIFF
--- a/src/lib/Parser/RuleParser.php
+++ b/src/lib/Parser/RuleParser.php
@@ -55,9 +55,9 @@ final class RuleParser extends FileParser {
         $pattern = $arr['pattern'];
         $message = $arr['message'];
 
-        $before = $arr['before'];
-        $after = $arr['after'];
-        $justification = $arr['justification'];
+        $before = $arr['before'] ?? null;
+        $after = $arr['after'] ?? null;
+        $justification = $arr['justification'] ?? null;
 
         if (!\is_string($id)) {
             throw new InvalidRule('id');


### PR DESCRIPTION
## Before

```
bin/phinder -r sample/phinder.yml -p sample/index.php
PHP Notice:  Undefined index: before in /home/wata727/ghq/github.com/tomokinakamaru/phinder/src/lib/Parser/RuleParser.php on line 58
PHP Stack trace:
PHP   1. {main}() /home/wata727/ghq/github.com/tomokinakamaru/phinder/bin/phinder:0
PHP   2. Generator->valid() /home/wata727/ghq/github.com/tomokinakamaru/phinder/bin/phinder:113
PHP   3. Phinder\API::phind() /home/wata727/ghq/github.com/tomokinakamaru/phinder/bin/phinder:113
PHP   4. Phinder\API::parseRule() /home/wata727/ghq/github.com/tomokinakamaru/phinder/src/lib/API.php:10
PHP   5. iterator_to_array() /home/wata727/ghq/github.com/tomokinakamaru/phinder/src/lib/API.php:23
PHP   6. Phinder\Parser\RuleParser->parseFile() /home/wata727/ghq/github.com/tomokinakamaru/phinder/src/lib/API.php:23
PHP   7. Phinder\Parser\RuleParser->parseArray() /home/wata727/ghq/github.com/tomokinakamaru/phinder/src/lib/Parser/RuleParser.php:39
PHP Notice:  Undefined index: after in /home/wata727/ghq/github.com/tomokinakamaru/phinder/src/lib/Parser/RuleParser.php on line 59
PHP Stack trace:
PHP   1. {main}() /home/wata727/ghq/github.com/tomokinakamaru/phinder/bin/phinder:0
PHP   2. Generator->valid() /home/wata727/ghq/github.com/tomokinakamaru/phinder/bin/phinder:113
PHP   3. Phinder\API::phind() /home/wata727/ghq/github.com/tomokinakamaru/phinder/bin/phinder:113
PHP   4. Phinder\API::parseRule() /home/wata727/ghq/github.com/tomokinakamaru/phinder/src/lib/API.php:10
PHP   5. iterator_to_array() /home/wata727/ghq/github.com/tomokinakamaru/phinder/src/lib/API.php:23
PHP   6. Phinder\Parser\RuleParser->parseFile() /home/wata727/ghq/github.com/tomokinakamaru/phinder/src/lib/API.php:23
PHP   7. Phinder\Parser\RuleParser->parseArray() /home/wata727/ghq/github.com/tomokinakamaru/phinder/src/lib/Parser/RuleParser.php:39
PHP Notice:  Undefined index: justification in /home/wata727/ghq/github.com/tomokinakamaru/phinder/src/lib/Parser/RuleParser.php on line 60
PHP Stack trace:
PHP   1. {main}() /home/wata727/ghq/github.com/tomokinakamaru/phinder/bin/phinder:0
PHP   2. Generator->valid() /home/wata727/ghq/github.com/tomokinakamaru/phinder/bin/phinder:113
PHP   3. Phinder\API::phind() /home/wata727/ghq/github.com/tomokinakamaru/phinder/bin/phinder:113
PHP   4. Phinder\API::parseRule() /home/wata727/ghq/github.com/tomokinakamaru/phinder/src/lib/API.php:10
PHP   5. iterator_to_array() /home/wata727/ghq/github.com/tomokinakamaru/phinder/src/lib/API.php:23
PHP   6. Phinder\Parser\RuleParser->parseFile() /home/wata727/ghq/github.com/tomokinakamaru/phinder/src/lib/API.php:23
PHP   7. Phinder\Parser\RuleParser->parseArray() /home/wata727/ghq/github.com/tomokinakamaru/phinder/src/lib/Parser/RuleParser.php:39
sample/index.php:4:5    var_dump($a, $b)        Do not use var_dump. (sample.var_dump)
sample/index.php:3:5    in_array($needle, $haystack)    Specify 3rd parameter explicitly when calling in_array to avoid unexpected comparison results. (sample.in_array_without_3rd_param)
```

## After

```
bin/phinder -r sample/phinder.yml -p sample/index.php
sample/index.php:4:5    var_dump($a, $b)        Do not use var_dump. (sample.var_dump)
sample/index.php:3:5    in_array($needle, $haystack)    Specify 3rd parameter explicitly when calling in_array to avoid unexpected comparison results. (sample.in_array_without_3rd_param)
```